### PR TITLE
Add SonicPrint

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
 - [Collage Generator for Last.fm](https://github.com/jerboa88/Collage-Generator-for-Last.fm) - an open-source command-line app to generate a collage of your favorite albums based on Last.fm scrobbles
 - [Musicorum](https://www.musicorumapp.com/generate) - open-source Last.fm collage generator allowing you to select different themes, grid size, and time periods
 - [Riffology](https://lastfm.riffology.co) - Collage generator for albums, artists and uses multiple sources to fetch unknown album art
+- [SonicPrint](https://sonicprint.art) - generate customizable Last.fm
+  album collages and Instagram stories with editable covers and grid sizes
 
 ## Word Cloud Makers
 


### PR DESCRIPTION
## Summary
- Add SonicPrint to the Collage Makers section
- Link to the public app at https://sonicprint.art

## Notes
- SonicPrint generates customizable Last.fm album collages and Instagram stories with editable covers and grid sizes

## Verification
- Confirmed https://sonicprint.art returns HTTP 200
- Compared against recent accepted one-entry PRs (#3, #8, #11) for README style